### PR TITLE
Refactor packagecloud integration

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,6 @@
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
   "version": "0.1.0",
   "command_line_interface": ["Click", "No command-line interface"],
-  "packagecloud": ["Enable use of other libraries from package cloud",
-                   "No dependency on other package cloud libraries"]
+  "packagecloud_repo": "syapse/General",
+  "packagecloud_master_token": ""
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
   "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
   "version": "0.1.0",
   "command_line_interface": ["Click", "No command-line interface"],
-  "packagecloud_repo": "syapse/General",
-  "packagecloud_master_token": ""
+  "enable_packagecloud": ["yes", "no"],
+  "packagecloud_repo": "{% if cookiecutter.enable_packagecloud | lower == 'yes' %}syapse/General{% else %}DISABLED{% endif %}",
+  "packagecloud_master_token": "{% if cookiecutter.enable_packagecloud | lower == 'yes' %}5a1f72e8a735582d8c435fc3429c1591cd869c657f9a94d7{% else %}DISABLED{% endif %}"
 }

--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -1,62 +1,26 @@
 #!/usr/bin/env bash
 
-echo 'Initializing repository...'
-git init .
 
-echo 'Setting upstream origin to git@github.com:{{ cookiecutter.github_repo }}.git'
-git remote add origin 'git@github.com:{{ cookiecutter.github_repo }}.git'
+initialize_repo () {
+    echo 'Initializing repository...'
+    git init .
 
-if [[ '{{ cookiecutter.command_line_interface|lower }}' =~ no ]]
-then
-   rm '{{ cookiecutter.project_slug }}/cli.py'
-fi
+    echo 'Setting upstream origin to git@github.com:{{ cookiecutter.github_repo }}.git'
+    git remote add origin 'git@github.com:{{ cookiecutter.github_repo }}.git'
+}
 
-if [[ '{{ cookiecutter.packagecloud|lower }}' =~ enable ]]
-then
-   # Get packagecloud API token
-   if [ -z "${PACKAGECLOUD_TOKEN}" ]
-   then
-      echo '${PACKAGECLOUD_TOKEN} is not set, please find your token at'
-      echo '    https://packagecloud.io/api_token'
-      read -p 'and enter it here: ' PACKAGECLOUD_TOKEN
-   fi
-   echo "Using ${PACKAGECLOUD_TOKEN} package cloud api token"
 
-   # Get or create read token
+remove_cli_code () {
+    if [[ '{{ cookiecutter.command_line_interface|lower }}' =~ no ]]
+    then
+        rm -f '{{ cookiecutter.project_slug }}/cli.py'
+    fi
+}
 
-   # python subroutine for parsing read_tokens result from packagecloud
-   pythontmpfile=$(mktemp /tmp/parse_json.XXXXXX)
-   cat > $pythontmpfile <<EOF
-import sys
-import json
 
-for token in json.load(sys.stdin).get('read_tokens', []):
-    if token['name'] == '{{ cookiecutter.project_dash_slug }}':
-        sys.stdout.write(token['value'])
-        sys.exit(0)
-sys.stderr.write('Could not find read token\n')
-sys.exit(1)
-EOF
+main () {
+    initialize_repo
+    remove_cli_code
+}
 
-   # When copy/pasting this code into a different cookie cutter please create a new master token.
-
-   MASTER_TOKEN=5a1f72e8a735582d8c435fc3429c1591cd869c657f9a94d7
-
-   # NB: the MASTER_TOKEN is not secret. The package cloud documentation says:
-   #
-   # That means that you can safely give master tokens to customers, embed them in
-   # configuration management manifests, or otherwise distribute them to untrusted parties.
-
-   READ_TOKENS_API=api/v1/repos/syapse/General/master_tokens/${MASTER_TOKEN}/read_tokens.json
-   # Creating read token may fail if the script is called twice, with error response json, but 0 bash status code)
-   # We ignore result.
-   curl -o /dev/null -X POST -F "read_token[name]={{ cookiecutter.project_dash_slug }}" https://${PACKAGECLOUD_TOKEN}:@packagecloud.io/${READ_TOKENS_API}
-   # Get read tokens (either freshly created or old one)
-   READ_TOKEN=$(curl https://${PACKAGECLOUD_TOKEN}:@packagecloud.io/${READ_TOKENS_API} | python $pythontmpfile)
-
-   rm $pythontmpfile
-
-   # Edit Pipfile
-   sed -i '' -e 's/[$]{READ_TOKEN}/'${READ_TOKEN}/ Pipfile
-
-fi
+main "$@"

--- a/{{cookiecutter.project_dash_slug}}/.env.example
+++ b/{{cookiecutter.project_dash_slug}}/.env.example
@@ -1,0 +1,4 @@
+PACKAGECLOUD_REPO={{cookiecutter.packagecloud_repo}}
+PACKAGECLOUD_MASTER_TOKEN={{cookiecutter.packagecloud_master_token}}
+PACKAGECLOUD_TOKEN=
+PACKAGECLOUD_READ_TOKEN=

--- a/{{cookiecutter.project_dash_slug}}/.env.example
+++ b/{{cookiecutter.project_dash_slug}}/.env.example
@@ -1,4 +1,6 @@
+{% if cookiecutter.enable_packagecloud | lower == 'yes' %}
 PACKAGECLOUD_REPO={{cookiecutter.packagecloud_repo}}
 PACKAGECLOUD_MASTER_TOKEN={{cookiecutter.packagecloud_master_token}}
 PACKAGECLOUD_TOKEN=
 PACKAGECLOUD_READ_TOKEN=
+{% endif %}

--- a/{{cookiecutter.project_dash_slug}}/Pipfile
+++ b/{{cookiecutter.project_dash_slug}}/Pipfile
@@ -3,13 +3,11 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
-{% if 'enable' in  cookiecutter.packagecloud|lower %}
 [[source]]
 # Please don't reuse the read token below in other projects. Generate a new one.
-url = "https://${READ_TOKEN}:@packagecloud.io/syapse/General/pypi/simple"
+url = "https://$PACKAGECLOUD_READ_TOKEN:@packagecloud.io/syapse/General/pypi/simple"
 verify_ssl = true
 name = "packagecloud"
-{% endif %}
 
 [packages]
 "e1839a8" = {editable = true, path = "."}

--- a/{{cookiecutter.project_dash_slug}}/Pipfile
+++ b/{{cookiecutter.project_dash_slug}}/Pipfile
@@ -3,11 +3,15 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 name = "pypi"
 
+{% if cookiecutter.enable_packagecloud | lower == 'yes' %}
 [[source]]
 # Please don't reuse the read token below in other projects. Generate a new one.
 url = "https://$PACKAGECLOUD_READ_TOKEN:@packagecloud.io/syapse/General/pypi/simple"
 verify_ssl = true
 name = "packagecloud"
+
+{% endif %}
+[dev-packages]
 
 [packages]
 "e1839a8" = {editable = true, path = "."}

--- a/{{cookiecutter.project_dash_slug}}/bin/setup
+++ b/{{cookiecutter.project_dash_slug}}/bin/setup
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+
+generate_env () {
+    if [[ -f '.env' ]]
+    then
+        read -p 'Do you want to overwrite .env with .env.example? [y/N]' -r
+        if [[ $REPLY =~ ^[Yy]$ ]]
+        then
+            cp .env.example .env
+        fi
+    else
+        cp .env.example .env
+    fi
+}
+
+
+configure_packagecloud () {
+    # Prompt the user for a packagecloud API token if not set.
+
+    # shellcheck disable=1091
+    source .env
+
+    local api_token="$PACKAGECLOUD_TOKEN"
+    if [[ -z "$api_token" ]]
+    then
+        echo 'No PACKAGECLOUD_TOKEN was detected. Get your token from '
+        echo '    -> https://packagecloud.io/api_token'
+        read -p 'Enter your packagecloud token: ' -r api_token
+        sed -i'' "s/PACKAGECLOUD_TOKEN=/PACKAGECLOUD_TOKEN=$api_token/" .env
+    fi
+
+    local master_token="${PACKAGECLOUD_MASTER_TOKEN?Please export PACKAGECLOUD_MASTER_TOKEN}"
+    local repo="${PACKAGECLOUD_REPO? Please export PACKAGECLOUD_REPO}"
+    local read_tokens_api="https://$api_token:@packagecloud.io/api/v1/repos/$repo/master_tokens/$master_token/read_tokens.json"
+
+    echo "Creating a read token..."
+    curl --silent --fail --output /dev/null -X POST -F "read_token[name]={{ cookiecutter.project_dash_slug }}" "$read_tokens_api" \
+        || echo "A read token already exists for this project."
+
+    echo "Fetching the read token for this project..."
+    local read_token
+    read_token=$(curl --silent --show-error --fail "$read_tokens_api" | python -c "import sys, json; print(next(t['value'] for t in json.load(sys.stdin).get('read_tokens', []) if t.get('name') == '{{cookiecutter.project_dash_slug}}') or '')")
+
+    if [[ -z "$read_token" ]]
+    then
+        >&2 echo "There was a problem fetching the read token from packagecloud. Make sure your PACKAGECLOUD_REPO and PACAKGECLOUD_MASTER_TOKEN are correctly set in your environment."
+        exit 1
+    fi
+
+    sed -i'' "s/PACKAGECLOUD_READ_TOKEN=/PACKAGECLOUD_READ_TOKEN=$read_token/" .env
+
+    echo "Packagecloud was successfully configured. Credentials were written to .env."
+}
+
+
+display_instructions () {
+    echo "To start developing, run \`pipenv shell\`."
+}
+
+
+main () {
+    generate_env
+    configure_packagecloud
+    display_instructions
+}
+
+main "$@"

--- a/{{cookiecutter.project_dash_slug}}/bin/setup
+++ b/{{cookiecutter.project_dash_slug}}/bin/setup
@@ -15,6 +15,7 @@ generate_env () {
 }
 
 
+{% if cookiecutter.enable_packagecloud | lower == 'yes' %}
 configure_packagecloud () {
     # Prompt the user for a packagecloud API token if not set.
 
@@ -54,6 +55,7 @@ configure_packagecloud () {
 }
 
 
+{% endif %}
 display_instructions () {
     echo "To start developing, run \`pipenv shell\`."
 }
@@ -61,7 +63,9 @@ display_instructions () {
 
 main () {
     generate_env
+    {% if cookiecutter.enable_packagecloud | lower == 'yes' %}
     configure_packagecloud
+    {% endif %}
     display_instructions
 }
 

--- a/{{cookiecutter.project_dash_slug}}/bin/setup
+++ b/{{cookiecutter.project_dash_slug}}/bin/setup
@@ -14,13 +14,19 @@ generate_env () {
     fi
 }
 
-
 {% if cookiecutter.enable_packagecloud | lower == 'yes' %}
 configure_packagecloud () {
     # Prompt the user for a packagecloud API token if not set.
 
     # shellcheck disable=1091
     source .env
+
+    # If a read token already exists, return early.
+    if [[ ! -z "$PACKAGECLOUD_READ_TOKEN" ]] 
+    then
+        echo "Detected an existing PACKAGECLOUD_READ_TOKEN. Skipping configuration."
+        return
+    fi
 
     local api_token="$PACKAGECLOUD_TOKEN"
     if [[ -z "$api_token" ]]
@@ -54,7 +60,6 @@ configure_packagecloud () {
     echo "Packagecloud was successfully configured. Credentials were written to .env."
 }
 
-
 {% endif %}
 display_instructions () {
     echo "To start developing, run \`pipenv shell\`."
@@ -63,9 +68,7 @@ display_instructions () {
 
 main () {
     generate_env
-    {% if cookiecutter.enable_packagecloud | lower == 'yes' %}
-    configure_packagecloud
-    {% endif %}
+    {% if cookiecutter.enable_packagecloud | lower == 'yes' %}configure_packagecloud{% endif %}
     display_instructions
 }
 


### PR DESCRIPTION
The cookiecutter will always ask for a packagecloud repo and master token. This is a safe assumption (since the cookiecutter is only used within Syapse) and it's low-risk even if they don't pull anything from packagecloud. Having the additional source available will lower the barrier to entry for using other Syapse packages later.

The logic for configuring packagecloud authentication was moved into a `bin/setup` script. This ensures that we don't break `cookiecutter`'s `--no-input` and `--replay` options.

The `bin/setup` command essentially writes to a `.env` file which is sourced by `pipenv` when a developer wants to work on the project. The script will prompt them for a token if `PACKAGECLOUD_TOKEN` isn't set in the environment.