### PR TITLE
AP-27915: clarify naming convention issues with private library

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,10 @@ $ cookiecutter git@github.com:syapse/cookiecutter-pypackage.git
 
 # Follow the prompts to configure your project. See Cookiecutter Options below.
 
-# To test locally (2.7 and 3.6 only) you can use tox, if setup correctly (black magic):
-$ tox
+You are strongly advised to follow the naming convention of starting your project name
+with 'Syapse', and hence your package name with 'syapse_'. This is to avoid name
+collisions with packages at [PyPI](https://pypi.org)
 
-# To avoid black magic, use Docker for local testing
-$ docker build -t foo . && docker run -it foo
-```
 
 ## Cookiecutter Options
 
@@ -28,8 +26,8 @@ The following options can be specified when creating a new service.
 
 | Prompt                      | Description                                                                              |
 | --------------------------- | -----------------------------------------------------------------------------------------|
-| `project_name`              | The human-readable name of the new project  .                                            |
-| `project_slug`              | The name of the Python module to generate. Must be a Python-compatible identifier.       |
+| `project_name`              | The human-readable name of the new project (Should start with 'Syapse').                 |
+| `project_slug`              | The Python-compatible identifier of the generated module. Must start 'syapse_'.          |
 | `project_dash_slug`         | The top-level directory name, conventionally avoiding _.                                 |
 | `project_short_description` | A few words about the project.                                                           |
 | `python_2_7`                | Include python 2.7 support.                                                              |

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,9 +1,9 @@
 {
-  "project_name": "Python Boilerplate",
+  "project_name": "Syapse Python Boilerplate",
   "project_slug": "{{ cookiecutter.project_name.lower().replace(' ', '_').replace('-', '_') }}",
   "project_dash_slug": "{{ cookiecutter.project_slug.lower().replace('_', '-') }}",
   "github_repo": "syapse/{{ cookiecutter.project_dash_slug }}",
-  "project_short_description": "Python Boilerplate contains all the boilerplate you need to create a Python package.",
+  "project_short_description": "Syapse Python Boilerplate contains all the boilerplate you need to create a Python package.",
   "python_2_7": ["No", "Yes"],
   "version": "0.1.0",
   "command_line_interface": ["Click", "No command-line interface"],

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -12,3 +12,7 @@ if not re.match(MODULE_REGEX, module_name):
 
     #Exit to cancel project
     sys.exit(1)
+
+if not module_name.startswith("syapse_"):
+    print(('WARNING: the namespace for python libraries is global, and managed by pypi.org. '
+           'To avoid name collisions you are advised to use a syapse_ prefix.'))


### PR DESCRIPTION
@mianelson a couple of months ago I very briefly discussed naming conventions for python libraries with you and I aimed to defer to the choices made by the platform team. I hope this PR implements those choices, please check.

e.g. `WARNING: the namespace for python libraries is global, and managed by pypi.org. To avoid name collisions you are advised to use a syapse_ prefix.`
in
```
$ cookiecutter ../work/cookiecutter-pypackage/ -f
project_name [Syapse Python Boilerplate]: Foo
project_slug [foo]: 
project_dash_slug [foo]: 
github_repo [syapse/foo]: 
project_short_description [Syapse Python Boilerplate contains all the boilerplate you need to create a Python package.]: 
Select python_2_7:
1 - No
2 - Yes
Choose from 1, 2 [1]: 
version [0.1.0]: 
Select command_line_interface:
1 - Click
2 - No command-line interface
Choose from 1, 2 [1]: 
Select enable_packagecloud:
1 - yes
2 - no
Choose from 1, 2 [1]: 
packagecloud_read_token [Please generate one for me]: 
WARNING: the namespace for python libraries is global, and managed by pypi.org. To avoid name collisions you are advised to use a syapse_ prefix.
Leaving /git directory unchanged
No $PACKAGECLOUD_TOKEN environment variable. Get your token from 
    -> https://packagecloud.io/api_token
And enter your packagecloud token: --secret--
Creating a read token...
Fetching the read token for this project...
```